### PR TITLE
Tweaks to the DPS Simulator

### DIFF
--- a/gui/builtinViewColumns/__init__.py
+++ b/gui/builtinViewColumns/__init__.py
@@ -1,2 +1,3 @@
 __all__ = ["ammo", "ammoIcon", "attributeDisplay", "baseIcon", "baseName",
-           "capacitorUse", "maxRange", "price", "propertyDisplay", "state", "misc", "abilities", "sideEffects"]
+           "capacitorUse", "maxRange", "price", "propertyDisplay", "state", "misc", "abilities", "sideEffects",
+           "graphColor"]

--- a/gui/builtinViewColumns/graphColor.py
+++ b/gui/builtinViewColumns/graphColor.py
@@ -1,0 +1,28 @@
+# noinspection PyPackageRequirements
+import wx
+from eos.saveddata.implant import Implant
+from eos.saveddata.drone import Drone
+from eos.saveddata.module import Module, Slot, Rack
+from eos.saveddata.fit import Fit
+from eos.saveddata.targetResists import TargetResists
+from gui.viewColumn import ViewColumn
+from logbook import Logger
+
+pyfalog = Logger(__name__)
+
+
+class GraphColor(ViewColumn):
+    name = "Graph Color"
+
+    def __init__(self, view, params):
+        ViewColumn.__init__(self, view)
+        self.size = 24
+        self.maxsize = self.size
+        self.mask = wx.LIST_MASK_IMAGE
+        self.columnText = ""
+
+    def getImageId(self, stuff):
+        return self.fittingView.imageList.GenerateColorBitmap(self.fittingView.getColor(stuff))
+
+
+GraphColor.register()

--- a/gui/builtinViewColumns/graphColor.py
+++ b/gui/builtinViewColumns/graphColor.py
@@ -1,10 +1,5 @@
 # noinspection PyPackageRequirements
 import wx
-from eos.saveddata.implant import Implant
-from eos.saveddata.drone import Drone
-from eos.saveddata.module import Module, Slot, Rack
-from eos.saveddata.fit import Fit
-from eos.saveddata.targetResists import TargetResists
 from gui.viewColumn import ViewColumn
 from logbook import Logger
 

--- a/gui/cachingImageList.py
+++ b/gui/cachingImageList.py
@@ -26,6 +26,8 @@ from gui.bitmapLoader import BitmapLoader
 class CachingImageList(wx.ImageList):
     def __init__(self, width, height):
         wx.ImageList.__init__(self, width, height)
+        self.width = width
+        self.height = height
         self.map = {}
 
     def GetImageIndex(self, *loaderArgs):
@@ -36,3 +38,14 @@ class CachingImageList(wx.ImageList):
                 return -1
             id_ = self.map[loaderArgs] = wx.ImageList.Add(self, bitmap)
         return id_
+
+    def GenerateColorBitmap(self, color):
+        id_ = self.map.get(color)
+        if id_ is None:
+            bitmap = wx.EmptyBitmapRGBA(self.width, self.height, red=color.red, green=color.green, blue=color.blue, alpha=color.alpha)
+            if bitmap is None:
+                return -1
+            id_ = self.map[color] = wx.ImageList.Add(self, bitmap)
+        return id_
+
+

--- a/gui/graphFrame.py
+++ b/gui/graphFrame.py
@@ -119,6 +119,8 @@ class GraphFrame(wx.Frame):
         self.mainFrame = gui.mainFrame.MainFrame.getInstance()
         self.CreateStatusBar()
 
+        self.lineColor = {}
+
         sizer = wx.BoxSizer(wx.VERTICAL)
         self.SetSizer(sizer)
 
@@ -187,7 +189,6 @@ class GraphFrame(wx.Frame):
         self.markerX = 0
         self.selected = None
         self.nextColor = 0
-        self.lineColor = {}
         self.lineData = {}
         self.currentViewIndex = None
         self.currentView = None
@@ -470,6 +471,7 @@ class GraphFrame(wx.Frame):
         self.plotPanel.draw(lineDataGen, self.markerX)
         if self.selected:
             self.buttonLineColor.Enable()
+
             self.buttonLineColor.SetBackgroundColour(tuple(c * 255 for c in self.lineColor[self.selected]))
             fitID, tgtID = self.selected
             if tgtID is None:
@@ -501,10 +503,22 @@ class FitList(wx.Panel):
 
 class FitDisplay(gui.display.Display):
     DEFAULT_COLS = ["Base Icon",
+                    "Graph Color",
                     "Base Name:Attacker Name"]
 
     def __init__(self, parent):
         gui.display.Display.__init__(self, parent)
+
+    def getColor(self, fit):
+        '''
+        getColor is used as a callback for the Graph Color ViewColumn. This is where we determine what color to display
+        for the item. Must return a wx.Colour.
+        '''
+        t = self.Parent.frame.lineColor.get((fit.ID, None), None)
+        if t is None:
+            return wx.Colour(0, 0, 0, 1.0)
+        x = tuple(c * 255 for c in t)
+        return wx.Colour(x[0], x[1], x[2])
 
 
 class TargetList(wx.Panel):

--- a/gui/viewColumn.py
+++ b/gui/viewColumn.py
@@ -80,5 +80,6 @@ from gui.builtinViewColumns import (  # noqa: E402, F401
     price,
     propertyDisplay,
     state,
-    sideEffects
+    sideEffects,
+    graphColor
 )


### PR DESCRIPTION
As per https://github.com/pyfa-org/Pyfa/pull/1353#issuecomment-355804386, here's some changes to the pull request that I think we should definitely incorporate. I will continue to work on this PR while discussing the changes with you (I could push these to the branch that you PR'd so that's it's included, but I would like to have some conversation as to the direction this goes first)

Right now, simply adds a column strictly for a color representation of fits.

Note that the current implementation is pretty broken. I'm hooking into `GraphFrame.lineColor` to determine the color for the fit. There are two problems with this: 

1) `lineColor` doesn't seem like it's initialized fully by the time Fit View is rendered, thus it gets a default when opening the frame with a fit pre-loaded. This can be worked around by opening graph frame, then loading a fit into it. 
2) This doesn't really work at all for the Simulator, only the Calculator, since `lineColor` is defined with a pair. When we try to get the color, the callback only uses the fit that it needs the color for, and doesn't know about the other fit in the equation. Additionally, a fit on the left can have 3 or 4 different colors depending on which pair, so it doesn't have a single color representation.

Additionally, if you change the color, the fit list isn't automatically refreshed. I plan to move the color picker to the column itself, so I didn't really mess with getting it working properly.

The fix for both of those is to assign a color for each fit / target profile from the get go, and generate the `lineColor` based on that, rather than the inverse. Would take a bit more work, and would like your input before delving into this further. :)

  